### PR TITLE
Allow Site.Copyright to be used

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,9 +1,13 @@
 <div class="flex flex-col justify-center p-10">
   {{/* Copyright */}}
   <p class="text-center text-slate-700 dark:text-slate-400">
-    &copy;
-    {{ now.Format "2006" }}
-    {{ .Site.Params.Author.name | markdownify | emojify }}
+    {{ with .Site.Copyright }}
+      {{ . | markdownify | emojify }}
+    {{ else }}
+      &copy;
+      {{ now.Format "2006" }}
+      {{ .Site.Params.Author.name | markdownify | emojify }}
+    {{ end }}
   </p>
 
   {{/* Powered by */}}


### PR DESCRIPTION
The copyright is usually configured in the hugo configuration. This inserts the copyright notice if it is given. This allows for custom licenses.

In my case, I want my blog to be under CC-BY-SA. This makes it possible.